### PR TITLE
Update RoleList.tsx (Fix role name extending out of the button)

### DIFF
--- a/src/components/pages/settings/permissions/RoleList.tsx
+++ b/src/components/pages/settings/permissions/RoleList.tsx
@@ -85,8 +85,9 @@ export const RoleList = observer(
                         <ButtonItem
                             key={role.id}
                             selected={role.id === selected}
-                            style={{ color: role.colour! }}
-                            onClick={() => onSelect?.(role.id)}>
+                            style={{ overflow: 'hidden', color: role.colour! }}
+                            onClick={() => onSelect?.(role.id)}
+                            title={role.name}>
                             <Rank>{role_rank}</Rank>
                             {role.name}
                             {typeof rank === "number" && role_rank <= rank && (


### PR DESCRIPTION
Issue where the role name extends out of the button item. 

- overflow: 'hidden', takes away the access characters from overlapping over the role permission section.

- title, shows the fill role name on hover of the item.

(tested text wrapping but doesn't look good at all, overflow hidden is much cleaner).